### PR TITLE
Restart game when no valid minigame to play

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -1224,6 +1224,7 @@ function Ware_StartMinigameInternal(is_boss)
 		if (++attempts > 16)
 		{
 			Ware_Error("No valid %s found to pick. There may not be enough minimum players", is_boss ? "bossgame" : "minigame")
+			SetConvarValue("mp_restartgame", 5)
 			return
 		}
 		


### PR DESCRIPTION
Bandaid fix when game craps out for no reason at the end and causes massive disappointment