### PR TITLE
Add a "Sit Out" special round.

### DIFF
--- a/cfg/tf2ware_ultimate/specialrounds.cfg
+++ b/cfg/tf2ware_ultimate/specialrounds.cfg
@@ -22,6 +22,7 @@ opposite_day
 random_score
 reversed_text
 simon
+sit_out
 size_matters
 skull
 slow_mo

--- a/scripts/vscripts/tf2ware_ultimate/specialrounds/sit_out.nut
+++ b/scripts/vscripts/tf2ware_ultimate/specialrounds/sit_out.nut
@@ -1,0 +1,71 @@
+special_round <- Ware_SpecialRoundData
+({
+	name = "Sit Out"
+	author = "rake"
+	description = "Winning streaks reward you with missing out on the next minigame!"
+})
+
+SIT_OUT_AMOUNT <- 1
+SIT_OUT_THRESHOLD <- 9
+
+function OnStart()
+{
+	foreach (player in Ware_Players.filter(@(i, player) (player.GetTeam() & TF_TEAM_MASK) != 0))
+	{
+		local special = Ware_GetPlayerSpecialRoundData(player)
+		special.won_microgames <- 0
+		special.sit_out <- 0
+	}
+}
+
+function OnPlayerConnect(player)
+{
+	local special = Ware_GetPlayerSpecialRoundData(player)
+	special.won_microgames <- 0
+	special.sit_out <- 0
+}
+
+function OnMinigameStart()
+{
+	foreach (player in Ware_Players)
+	{
+		local special = Ware_GetPlayerSpecialRoundData(player)
+		if (special.sit_out)
+		{
+			local text = format("You are out for %d more microgames.", special.sit_out--);
+			Ware_ShowText(player, CHANNEL_MISC, text, 4.98)
+		}
+	}
+}
+
+function OnCalculateScore(data)
+{
+	local special = Ware_GetPlayerSpecialRoundData(data.player)
+	if (data.passed)
+	{
+		if (++special.won_microgames >= SIT_OUT_THRESHOLD)
+		{
+			special.sit_out = SIT_OUT_AMOUNT
+			special.won_microgames = 0
+		}
+	}
+	else
+	{
+		special.won_microgames = 0
+	}
+
+	return false
+}
+
+function OnSpeedup()
+{
+	local threshold = --SIT_OUT_THRESHOLD
+	Ware_ChatPrint(null, "Winning {color}{int}{color} microgames in a row will now make you sit-out!", COLOR_RED, threshold, TF_COLOR_DEFAULT)
+}
+
+function GetValidPlayers()
+{
+	return Ware_Players.filter(@(idx, player) (
+		Ware_GetPlayerSpecialRoundData(player).sit_out == 0
+	))
+}


### PR DESCRIPTION
This special round punishes players who win too much by making them sit-out the next microgame.

The threshold for the sit-out starts at nine concurrent wins, and is decreased by one everytime the round is sped up, meaning down to six normally and four with Extended Round.

<details>
<summary>Old version</summary>
<br>
This special round punishes players who lose by making them sit-out the next microgame, with the duration increasing everytime they lose a microgame.

Is this fair? No.

Potential review nitpicks:
- `TotalLosses` is inaccurate since it will increment any remaining sit-outs even if the round reached the boss.
- Players who have an active sit-out won't be able to play the boss, or multiple if Double Trouble rolls a second boss, arguably this is intentional.
- Not sure if the center text in `OnMinigameStart` is a good idea.
- The text duration in `Ware_ShowText` is completely random.
- I use "minigames" in the description and "microgames" in `OnEnd`
</details>