### PR TITLE
Lag Compensate Typing Minigames

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -251,11 +251,7 @@ function Ware_SetupMap()
 	ClientCmd <- CreateEntitySafe("point_clientcommand")
 	
 	for (local trigger; trigger = FindByClassname(trigger, "func_respawnroom");)
-	{
 		Ware_RespawnRooms.append(trigger)
-
-		trigger.SetTeam(0) // hack: game changes respawn rooms with unassigned team to the team of spawn points inside
-	}
 	
 	// avoid adding the think again to not break global execution order
 	if (World.GetScriptThinkFunc() != "Ware_OnUpdate")

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -251,7 +251,11 @@ function Ware_SetupMap()
 	ClientCmd <- CreateEntitySafe("point_clientcommand")
 	
 	for (local trigger; trigger = FindByClassname(trigger, "func_respawnroom");)
+	{
 		Ware_RespawnRooms.append(trigger)
+
+		trigger.SetTeam(0) // hack: game changes respawn rooms with unassigned team to the team of spawn points inside
+	}
 	
 	// avoid adding the think again to not break global execution order
 	if (World.GetScriptThinkFunc() != "Ware_OnUpdate")

--- a/scripts/vscripts/tf2ware_ultimate/minigames/type_map.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/type_map.nut
@@ -3,7 +3,7 @@ minigame <- Ware_MinigameData
 	name            = "Say the Map"
 	author          = ["ficool2"]
 	description     = "Say the name of the map!"
-	duration        = 6.0
+	duration        = 6.0	+ Ware_GetTimeScale() // extra time for lag compensation
 	end_delay       = 0.5
 	music           = "whatsthat"
 	suicide_on_end  = true
@@ -87,9 +87,11 @@ function OnStart()
 			Ware_PassPlayer(player, true)
 		}
 	}
+
+	Ware_CreateTimer(@() OnNonLagCompensatedEnd(), Ware_Minigame.duration - Ware_GetTimeScale()) // fire the end early before lag compensation happens
 }
 
-function OnEnd()
+function OnNonLagCompensatedEnd()
 {
 	Ware_ChatPrint(null, "The correct answer was {color}{str}{color} ({str})", 
 		COLOR_LIME, map[1], TF_COLOR_DEFAULT, RandomElement(map[0]))
@@ -135,7 +137,7 @@ function OnPlayerSay(player, text)
 {	
 	if (MatchesMap(text.tolower()))
 	{
-		if (player.IsAlive())
+		if (player.IsAlive() && Time() - GetPlayerLatency(player) < Ware_MinigameStartTime + Ware_Minigame.duration - Ware_GetTimeScale()) // pass the player if they typed it in time but server received it late
 		{
 			Ware_PassPlayer(player, true)
 			if (first)

--- a/scripts/vscripts/tf2ware_ultimate/minigames/type_time.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/type_time.nut
@@ -8,7 +8,7 @@ minigame <- Ware_MinigameData
 	name           = "Say the Time"
 	author         = "ficool2"
 	description    = "Say the time!"
-	duration       = 7.0
+	duration       = 7.0 + Ware_GetTimeScale() // extra time for lag compensation
 	location       = "dirtsquare"
 	music          = "countdown"
 	start_freeze   = 0.5
@@ -85,9 +85,11 @@ function OnStart()
 	clock.SetPoseParameter(clock.LookupPoseParameter("minutes"), minute / 60.0)
 	clock.SetPoseParameter(clock.LookupPoseParameter("hours"), hour / 12.0 + ((1.0 / 12.0) * minute / 60.0))
 	clock.StudioFrameAdvance()
+
+	Ware_CreateTimer(@() OnNonLagCompensatedEnd(), Ware_Minigame.duration - Ware_GetTimeScale()) // fire the end early before lag compensation happens
 }
 
-function OnEnd()
+function OnNonLagCompensatedEnd()
 {
 	Ware_ChatPrint(null, "The correct time was {color}{%02d}:{%02d}{color} or {color}{%02d}:{%02d}", 
 		COLOR_LIME, hour, minute, TF_COLOR_DEFAULT, COLOR_LIME, hour + 12, minute)
@@ -119,7 +121,7 @@ function OnPlayerSay(player, text)
 	
 	if (accepted_text.find(clean_text) != null)
 	{
-		if (player.IsAlive())
+		if (player.IsAlive() && Time() - GetPlayerLatency(player) < Ware_MinigameStartTime + Ware_Minigame.duration - Ware_GetTimeScale()) // pass the player if they typed it in time but server received it late
 		{
 			Ware_PassPlayer(player, true)
 			if (first)


### PR DESCRIPTION
Gives an extra second for lag compensation, takes timescale into account, I am aware this is not the cleanest way of doing it, but it seems to get the job done.

Also make color typing minigame only precache the used screen overlay.