### PR TITLE
Fix Spawnroom Trigger and Disable On Round End

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -251,6 +251,7 @@ function Ware_SetupMap()
 	ClientCmd <- CreateEntitySafe("point_clientcommand")
 	
 	for (local trigger; trigger = FindByClassname(trigger, "func_respawnroom");)
+	{
 		Ware_RespawnRooms.append(trigger)
 		trigger.SetTeam(0) // hack: game changes respawn rooms with unassigned team to the team of spawn points inside
 	}
@@ -2044,7 +2045,9 @@ function Ware_GameOverInternal()
 		// TODO: Fix some weapons being weird in gameover (flamethrower doesn't damage, frontier justice removes crits, etc. Needs more testing)	
 	}
 	Ware_TogglePlayerLoadouts(false)
-	
+
+	Ware_ToggleRespawnRooms(false) // prevent losers from respawning
+
 	Ware_RoundEndMusicTimer <- CreateTimer(function() 
 	{
 		Ware_PlayGameSound(null, "results")
@@ -2148,8 +2151,6 @@ function Ware_GameOverInternal()
 			Ware_ChatPrint(null, "{color}Nobody won!?", TF_COLOR_DEFAULT)
 		}
 	}
-
-	Ware_ToggleRespawnRooms(false)
 }
 
 function Ware_OnUpdate()

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -2149,7 +2149,7 @@ function Ware_GameOverInternal()
 		}
 	}
 
-	Ware_CreateTimer(@() Ware_ToggleRespawnRooms(false), 2.0) // give time for winners to change class
+	Ware_ToggleRespawnRooms(false)
 }
 
 function Ware_OnUpdate()

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -252,6 +252,8 @@ function Ware_SetupMap()
 	
 	for (local trigger; trigger = FindByClassname(trigger, "func_respawnroom");)
 		Ware_RespawnRooms.append(trigger)
+		trigger.SetTeam(0) // hack: game changes respawn rooms with unassigned team to the team of spawn points inside
+	}
 	
 	// avoid adding the think again to not break global execution order
 	if (World.GetScriptThinkFunc() != "Ware_OnUpdate")
@@ -2146,6 +2148,8 @@ function Ware_GameOverInternal()
 			Ware_ChatPrint(null, "{color}Nobody won!?", TF_COLOR_DEFAULT)
 		}
 	}
+
+	Ware_CreateTimer(@() Ware_ToggleRespawnRooms(false), 2.0) // give time for winners to change class
 }
 
 function Ware_OnUpdate()


### PR DESCRIPTION
Game assigns teams to respawnrooms with unassigned team, this fixes it
Also disables it when someone wins to prevent losers respawning