### PR TITLE
Beep block lower tempo increase

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/bossgames/beep_block.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/beep_block.nut
@@ -24,7 +24,7 @@ minigame <- Ware_MinigameData
 
 // variables
 tempo            <- 0.0
-tempo_increase   <- 1.2
+tempo_increase   <- 1.12
 beat             <- 0.0
 bgm_offset       <- 0.0
 interrupted      <- false


### PR DESCRIPTION
The final section in ultimate's beep block is borderline impossible during speedup, this makes it possible yet still tight