### PR TITLE
Formalise minigame modes

### DIFF
--- a/cfg/tf2ware_ultimate/settings.cfg
+++ b/cfg/tf2ware_ultimate/settings.cfg
@@ -12,3 +12,5 @@ points_minigame       = 1
 points_bossgame       = 5
 // whether or not bonus points will be awarded. If 0 this is still available as a special round.
 bonus_points          = 0
+// maximum weight a minigame can have in rotation. If 0, this is unrestricted.
+max_miniweight        = 0

--- a/scripts/vscripts/tf2ware_ultimate/api/minigame.nut
+++ b/scripts/vscripts/tf2ware_ultimate/api/minigame.nut
@@ -61,6 +61,7 @@ class Ware_MinigameData
 	// Maximum amount of players needed to start, default is 256
 	max_players     = null
 	// Number of modes the minigame has, default is 1. This is used for minigames that share code but have variations such as Simon Says.
+	// Setting a higher value than 1 will randomly assign a value Ware_MinigameMode every time the minigame starts between 0 and (value - 1), which can be referred to for different modes
 	modes           = null
 	// Whether players will be flagged as passed when minigame starts, default is false
 	start_pass		= null

--- a/scripts/vscripts/tf2ware_ultimate/api/minigame.nut
+++ b/scripts/vscripts/tf2ware_ultimate/api/minigame.nut
@@ -8,6 +8,7 @@ class Ware_MinigameData
 		location        = "home"
 		min_players     = 0
 		max_players     = 256
+		modes           = 1
 		start_pass      = false
 		allow_damage    = false
 		allow_suicide   = false
@@ -51,7 +52,7 @@ class Ware_MinigameData
 	// == Optional settings ==
 	
 	// Music to play when the minigame starts
-	// If you are going to be playing music yourself, make sure to precache it in OnPrecache with Ware_PrecacheMinigameMusic
+	// If you are going to be playing music separate from this parameter, make sure to precache it in OnPrecache with Ware_PrecacheMinigameMusic
 	music			= null
 	// Map location to teleport to (Ware_Location enum), default is home
 	location		= null
@@ -59,6 +60,8 @@ class Ware_MinigameData
 	min_players		= null
 	// Maximum amount of players needed to start, default is 256
 	max_players     = null
+	// Number of modes the minigame has, default is 1. This is used for minigames that share code but have variations such as Simon Says.
+	modes           = null
 	// Whether players will be flagged as passed when minigame starts, default is false
 	start_pass		= null
 	// Is damage to other players allowed? Default is false

--- a/scripts/vscripts/tf2ware_ultimate/config.nut
+++ b/scripts/vscripts/tf2ware_ultimate/config.nut
@@ -50,6 +50,7 @@ function Ware_LoadConfigSettings()
 	Ware_PointsMinigame       <- 1
 	Ware_PointsBossgame       <- 5
 	Ware_BonusPoints          <- 0
+	Ware_MaxMinigameWeight    <- 0
 		
 	local settings_map = 
 	{
@@ -61,6 +62,7 @@ function Ware_LoadConfigSettings()
 		points_minigame        = "Ware_PointsMinigame"
 		points_bossgame        = "Ware_PointsBossgame"
 		bonus_points           = "Ware_BonusPoints"
+		max_miniweight         = "Ware_MaxMinigameWeight"
 	}
 	
 	local file = Ware_LoadConfigFile("settings")

--- a/scripts/vscripts/tf2ware_ultimate/default/settings.nut
+++ b/scripts/vscripts/tf2ware_ultimate/default/settings.nut
@@ -12,4 +12,6 @@ points_minigame       = 1
 // points for winning a bossgame
 points_bossgame       = 5
 // whether or not bonus points will be awarded. If 0 this is still available as a special round.
-bonus_points          = 0"
+bonus_points          = 0
+// maximum weight a minigame can have in rotation. If 0, this is unrestricted.
+max_miniweight        = 0"

--- a/scripts/vscripts/tf2ware_ultimate/dev.nut
+++ b/scripts/vscripts/tf2ware_ultimate/dev.nut
@@ -94,6 +94,28 @@ Ware_DevCommands <-
 		}
 		Ware_ChatPrint(null, "{str} forced next special round to '{str}'", Ware_DevCommandTitle(player), Ware_DebugNextSpecialRound)
 	}
+	"forcemode": function(player, text)
+	{
+		local args = split(text, " ")
+		if (args.len() >= 1)
+		{
+			local mode = args[0].tointeger()
+			if(typeof(mode) == "integer")
+			{
+				Ware_DebugForceMode = mode
+				Ware_ChatPrint(null, "{str} set moded minigames to mode {int}", Ware_DevCommandTitle(player), Ware_DebugForceMode)
+			}
+			else
+			{
+				Ware_ChatPrint(player, "Arguments: <mode>")
+			}
+		}
+		else
+		{
+			Ware_DebugForceMode = null
+			Ware_ChatPrint(null, "{str} cleared forced mode for moded minigames", Ware_DevCommandTitle(player))
+		}	
+	}
 	"shownext": function(player, text)
 	{
 		local vars = [

--- a/scripts/vscripts/tf2ware_ultimate/dev.nut
+++ b/scripts/vscripts/tf2ware_ultimate/dev.nut
@@ -100,14 +100,14 @@ Ware_DevCommands <-
 		if (args.len() >= 1)
 		{
 			local mode = args[0].tointeger()
-			if(typeof(mode) == "integer")
+			if(typeof(mode) == "integer" && mode >= 0)
 			{
 				Ware_DebugForceMode = mode
 				Ware_ChatPrint(null, "{str} set moded minigames to mode {int}", Ware_DevCommandTitle(player), Ware_DebugForceMode)
 			}
 			else
 			{
-				Ware_ChatPrint(player, "Arguments: <mode>")
+				Ware_ChatPrint(player, "Arguments: <mode>, where mode >= 0")
 			}
 		}
 		else

--- a/scripts/vscripts/tf2ware_ultimate/dev.nut
+++ b/scripts/vscripts/tf2ware_ultimate/dev.nut
@@ -99,8 +99,8 @@ Ware_DevCommands <-
 		local args = split(text, " ")
 		if (args.len() >= 1)
 		{
-			local mode = args[0].tointeger()
-			if(typeof(mode) == "integer" && mode >= 0)
+			local mode = StringToInteger(args[0])
+			if (mode != null && mode >= 0)
 			{
 				Ware_DebugForceMode = mode
 				Ware_ChatPrint(null, "{str} set moded minigames to mode {int}", Ware_DevCommandTitle(player), Ware_DebugForceMode)

--- a/scripts/vscripts/tf2ware_ultimate/events.nut
+++ b/scripts/vscripts/tf2ware_ultimate/events.nut
@@ -227,8 +227,7 @@ function OnGameEvent_teamplay_round_start(params)
 	Ware_ToggleTruce(true)
 
 	Ware_MinigameRotation.clear()
-	foreach (minigame in Ware_Minigames)
-		Ware_MinigameRotation.append(minigame)
+	Ware_ReloadMinigameRotation(false)
 	
 	// special rounds always occur every N rounds
 	// don't do two special rounds in a row (checks for special round from last round and then clears it, unless it's forced)

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -1370,8 +1370,12 @@ function Ware_ReloadMinigameRotation(is_boss)
 			
 		// Weight moded minigames more in rotation
 		foreach(minigame in Ware_Minigames)
-			for(local i = 0; i < Ware_MinigameCache[minigame].modes; i++)
+		{
+			local modes = Ware_MinigameCache[minigame].modes
+			local weight = Ware_MaxMinigameWeight == 0 ? modes : Min(modes, Ware_MaxMinigameWeight)
+			for(local i = 0; i < weight; i++)
 				Ware_MinigameRotation.append(minigame)
+		}
 		
 		return Ware_MinigameRotation
 	}	

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -159,7 +159,7 @@ if (!("Ware_DebugStop" in this))
 	Ware_DebugForceBossgameOnce <- false
 	Ware_DebugNextSpecialRound  <- ""
 	Ware_DebugNextSpecialRound2 <- []
-	Ware_DebugForceMode         <- 0
+	Ware_DebugForceMode         <- null
 }
 Ware_DebugForceTheme      <- ""
 Ware_DebugOldTheme        <- ""
@@ -1366,8 +1366,13 @@ function Ware_ReloadMinigameRotation(is_boss)
 	else
 	{
 		if (Ware_Minigames.len() == 0)
-			Ware_Error("Minigame rotation is empty")			
-		Ware_MinigameRotation = clone(Ware_Minigames)
+			Ware_Error("Minigame rotation is empty")
+			
+		// Weight moded minigames more in rotation
+		foreach(minigame in Ware_Minigames)
+			for(local i = 0; i < Ware_MinigameCache[minigame].modes; i++)
+				Ware_MinigameRotation.append(minigame)
+		
 		return Ware_MinigameRotation
 	}	
 }
@@ -1486,7 +1491,8 @@ function Ware_StartMinigameInternal(is_boss)
 		}
 		
 		// Set mode before scope is assigned in case any params depend on it
-		local modes = Ware_MinigameCache[minigame].modes
+		local cache = is_boss ? Ware_BossgameCache : Ware_MinigameCache
+		local modes = cache[minigame].modes
 		if (Ware_DebugForceMode != null)
 		{
 			// disallow modes above max mode

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -159,6 +159,7 @@ if (!("Ware_DebugStop" in this))
 	Ware_DebugForceBossgameOnce <- false
 	Ware_DebugNextSpecialRound  <- ""
 	Ware_DebugNextSpecialRound2 <- []
+	Ware_DebugForceMode         <- 0
 }
 Ware_DebugForceTheme      <- ""
 Ware_DebugOldTheme        <- ""
@@ -1486,7 +1487,14 @@ function Ware_StartMinigameInternal(is_boss)
 		
 		// Set mode before scope is assigned in case any params depend on it
 		local modes = Ware_MinigameCache[minigame].modes
-		if(modes > 1)
+		if (Ware_DebugForceMode != null)
+		{
+			// disallow modes above max mode
+			Ware_MinigameMode = Min(Ware_DebugForceMode, modes - 1)
+			if(modes > 1 && Ware_MinigameMode != Ware_DebugForceMode)
+				printf("[TF2Ware] Forced mode %d exceeds highest minigame mode. Using highest mode %d instead...\n", Ware_DebugForceMode, Ware_MinigameMode)
+		}
+		else if (modes > 1)
 			Ware_MinigameMode = RandomInt(0, modes - 1)
 		else
 			Ware_MinigameMode = 0	

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -176,6 +176,7 @@ if (!("Ware_BossgameRotation" in this))
 if (!("Ware_SpecialRoundRotation" in this))
 	Ware_SpecialRoundRotation <- []
 
+Ware_MinigameMode         <- 0
 Ware_MinigameSavedConvars <- {}
 Ware_MinigameEvents       <- []
 Ware_MinigameOverlay2Set  <- false
@@ -380,6 +381,7 @@ function Ware_PrecacheNext()
 				{
 					min_players = minigame.min_players
 					max_players = minigame.max_players
+					modes       = minigame.modes
 				}					
 			}
 			else if ("special_round" in scope)
@@ -1482,6 +1484,13 @@ function Ware_StartMinigameInternal(is_boss)
 			}
 		}
 		
+		// Set mode before scope is assigned in case any params depend on it
+		local modes = Ware_MinigameCache[minigame].modes
+		if(modes > 1)
+			Ware_MinigameMode = RandomInt(0, modes - 1)
+		else
+			Ware_MinigameMode = 0	
+		
 		Ware_MinigameScope = Ware_LoadMinigame(minigame, player_count, is_boss, is_forced)
 		if (Ware_MinigameScope)
 		{		
@@ -1510,7 +1519,10 @@ function Ware_StartMinigameInternal(is_boss)
 	Ware_Minigame = Ware_MinigameScope.minigame
 	Ware_MinigameStartTime = time
 	
-	printf("[TF2Ware] Starting %s '%s'\n", is_boss ? "bossgame" : "minigame", minigame)
+	if(Ware_Minigame.modes > 1)
+		printf("[TF2Ware] Starting %s '%s' with mode %d\n", is_boss ? "bossgame" : "minigame", minigame, Ware_MinigameMode)
+	else
+		printf("[TF2Ware] Starting %s '%s'\n", is_boss ? "bossgame" : "minigame", minigame)
 	
 	local player_indices_valid = ""
 	foreach (player in valid_players)

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -1496,7 +1496,7 @@ function Ware_StartMinigameInternal(is_boss)
 		
 		// Set mode before scope is assigned in case any params depend on it
 		local cache = is_boss ? Ware_BossgameCache : Ware_MinigameCache
-		local modes = cache[minigame].modes
+		local modes = minigame in cache ? cache[minigame].modes : 0
 		if (Ware_DebugForceMode != null)
 		{
 			// disallow modes above max mode

--- a/scripts/vscripts/tf2ware_ultimate/minigames/avoid_trains.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/avoid_trains.nut
@@ -5,11 +5,10 @@ minigame <- Ware_MinigameData
 	description   = "Dodge the trains!"
 	duration      = 6.0
 	music         = "train"
+	modes         = 2
 	start_pass    = true
 	fail_on_death = true
 })	
-
-mode <- RandomInt(0, 1)
 
 train_model <- "models/props_vehicles/train_enginecar.mdl"
 
@@ -36,7 +35,7 @@ function OnPrecache()
 
 function OnStart()
 {
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		local sound = RandomElement(train_rain)
 		Ware_PlaySoundOnAllClients(sound)
@@ -47,9 +46,9 @@ function OnStart()
 	local minigame_players = clone(Ware_MinigamePlayers)
 	
 	local train_count
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 		train_count = Max(Min(minigame_players.len() / 3, minigame_players.len()), 1)
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 		train_count = Min(minigame_players.len(), 2)
 	
 	local i = 0
@@ -68,13 +67,13 @@ function OnStart()
 function SpawnTrain(pos)
 {
 	local train_pos, train_ang, train_vel
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		train_pos = pos + Vector(0, 0, RandomFloat(1950, 2020))
 		train_ang = QAngle(90, 0, 0)
 		train_vel = Vector(0, 0, RandomFloat(-800, -1000))
 	}
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 	{
 		local axes = [[1, 0], [-1, 0], [0, -1], [0, 1]]
 		local axis = RandomElement(axes)

--- a/scripts/vscripts/tf2ware_ultimate/minigames/build_this.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/build_this.nut
@@ -7,12 +7,13 @@ building_modes <-
 	[ "Build a Teleporter Exit!",     "build_tele_exit",     OBJ_TELEPORTER ],
 	[ "Build Something!",             "build_something",     null           ],
 ]
-building_mode <- building_modes[mode]
+building_mode <- building_modes[Ware_MinigameMode]
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Build This"
 	author         = ["Gemidyne", "pokemonPasta"]
+	modes = 5
 	description    = building_mode[0]
 	duration       = 4.0
 	music          = "sillytime"
@@ -39,7 +40,7 @@ function OnGameEvent_player_builtobject(params)
 	if (!player)
 		return
 	
-	if (mode == 4)
+	if (Ware_MinigameMode == 4)
 	{
 		Ware_PassPlayer(player, true)
 	}
@@ -48,9 +49,9 @@ function OnGameEvent_player_builtobject(params)
 		local building_enum = params.object
 		if (building_enum == building_mode[2])
 		{
-			if ((mode < 2) ||
-				(mode == 2 && GetPropInt(building, "m_iObjectMode") != 1) || // tele entrance
-				(mode == 3 && GetPropInt(building, "m_iObjectMode") == 1) // tele exit
+			if ((Ware_MinigameMode < 2) ||
+				(Ware_MinigameMode == 2 && GetPropInt(building, "m_iObjectMode") != 1) || // tele entrance
+				(Ware_MinigameMode == 3 && GetPropInt(building, "m_iObjectMode") == 1) // tele exit
 			)
 			{
 				Ware_PassPlayer(player, true)

--- a/scripts/vscripts/tf2ware_ultimate/minigames/build_this.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/build_this.nut
@@ -1,4 +1,4 @@
-mode <- RandomInt(0, 4)
+
 building_modes <-
 [
 	[ "Build a Sentry!",              "build_sentry",        OBJ_SENTRYGUN  ],

--- a/scripts/vscripts/tf2ware_ultimate/minigames/double_jump.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/double_jump.nut
@@ -1,11 +1,11 @@
-mode <- RandomInt(0, 1)
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Double Jump"
 	author         = ["Gemidyne", "pokemonPasta"]
-	description    = mode == 0 ? "Double Jump!" : "Triple Jump!"
-	custom_overlay = mode == 0 ? "double_jump" : "triple_jump"
+	modes          = 2
+	description    = Ware_MinigameMode == 0 ? "Double Jump!" : "Triple Jump!"
+	custom_overlay = Ware_MinigameMode == 0 ? "double_jump" : "triple_jump"
 	duration       = 4.0
 	music          = "ringring"
 	fail_on_death  = true
@@ -28,7 +28,7 @@ function OnUpdate()
 	foreach (player in Ware_MinigamePlayers)
 	{
 		local airdashes = GetPropInt(player, "m_Shared.m_iAirDash") // doesn't count jump from ground - double == 1, triple == 2
-		switch (mode)
+		switch (Ware_MinigameMode)
 		{
 			case 0:
 				if (airdashes == 1)

--- a/scripts/vscripts/tf2ware_ultimate/minigames/flipper_ball.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/flipper_ball.nut
@@ -1,13 +1,13 @@
-mode <- RandomInt(0, 1)
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Flipper Ball"
 	author         = ["TonyBaretta", "ficool2"]
 	description    = "Get to the end!"
-	duration       = mode == 0 ? 27.0 : 28.0
+	modes          = 2
+	duration       = Ware_MinigameMode == 0 ? 27.0 : 28.0
 	end_delay      = 0.5	
-	music          = mode == 0 ? "fastbros" : "letsgetquirky"
+	music          = Ware_MinigameMode == 0 ? "fastbros" : "letsgetquirky"
 	location       = "pinball"
 	custom_overlay = "get_end"
 })
@@ -25,7 +25,7 @@ function OnPrecache()
 
 function OnTeleport(players)
 {
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		Ware_TeleportPlayersRow(players,
 			Ware_MinigameLocation.center_bottom,
@@ -33,7 +33,7 @@ function OnTeleport(players)
 			1000.0,
 			65.0, 65.0)
 	}
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 	{
 		Ware_TeleportPlayersRow(players,
 			Ware_MinigameLocation.center_top,
@@ -45,7 +45,7 @@ function OnTeleport(players)
 
 function OnStart()
 {
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 		Ware_SetGlobalLoadout(TF_CLASS_SCOUT)
 	else
 		Ware_SetGlobalLoadout(TF_CLASS_PYRO)
@@ -104,7 +104,7 @@ function OnTakeDamage(params)
 function OnUpdate()
 {
 	local win_threshold
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		local win_y = Ware_MinigameLocation.center_top.y + 64.0
 		foreach (player in Ware_MinigamePlayers)
@@ -114,7 +114,7 @@ function OnUpdate()
 		}
 
 	}
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 	{
 		local win_y = Ware_MinigameLocation.center_bottom.y - 400.0
 				

--- a/scripts/vscripts/tf2ware_ultimate/minigames/grapple_cutout.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/grapple_cutout.nut
@@ -1,14 +1,14 @@
-mode <- RandomInt(0, 1)
 
 minigame <- Ware_MinigameData
 ({
-	name            = mode == 1 ? "Grapple the Deer" : "Grapple the Cow"
+	name            = Ware_MinigameMode == 1 ? "Grapple the Deer" : "Grapple the Cow"
 	author          = ["TonyBaretta", "ficool2"]
-	description     = mode == 1 ? "Smack the deer!" : "Smack the cow!"
+	description     = Ware_MinigameMode == 1 ? "Smack the deer!" : "Smack the cow!"
 	duration        = 10.5
 	location        = "boxarena"
 	music           = "farm"
-	custom_overlay  = mode == 1 ? "grapple_deer" : "grapple_cow"
+	modes           = 2
+	custom_overlay  = Ware_MinigameMode == 1 ? "grapple_deer" : "grapple_cow"
 })
 
 cutout_models <-
@@ -16,7 +16,7 @@ cutout_models <-
 	"models/props_2fort/cow001_reference.mdl"
 	"models/props_sunshine/deer_cutout001.mdl"
 ]
-cutout_model <- cutout_models[mode]
+cutout_model <- cutout_models[Ware_MinigameMode]
 
 cow_sounds <- 
 [
@@ -46,7 +46,7 @@ function OnStart()
 {
 	Ware_SetGlobalLoadout(TF_CLASS_DEMOMAN, ["Ullapool Caber", "Grappling Hook"])
 	
-	local angles = mode == 1 ? QAngle(0, 90, 0) : QAngle(0, 0, 0)
+	local angles = Ware_MinigameMode == 1 ? QAngle(0, 90, 0) : QAngle(0, 0, 0)
 	
 	local lightorigin = Ware_SpawnEntity("info_target",
 	{
@@ -79,7 +79,7 @@ function OnStart()
 	})
 	SetPropEntity(prop, "m_hLightingOrigin", lightorigin)
 	
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		local sound = RandomElement(cow_sounds)
 		Ware_PlaySoundOnAllClients(sound)

--- a/scripts/vscripts/tf2ware_ultimate/minigames/kart.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/kart.nut
@@ -4,7 +4,6 @@ minigame <- Ware_MinigameData
 	author        = ["TonyBaretta", "pokemonPasta"]
 	music         = "moomoofarm"
 	description   = "Race to the End!"
-	modes         = 3
 	end_delay     = 0.5
 	start_freeze  = 0.5
 	allow_damage  = true
@@ -19,14 +18,15 @@ tracks <-
 	["kart_ramp",       Vector(-8000, -6475, -6527), 10.0],
 ]
 
+mode <- RandomInt(0, 2)
 if (Ware_Players.len() > 40)
-	Ware_MinigameMode = 0
+	mode = 0
 
-first <- Ware_MinigameMode != 2
+first <- mode != 2
 
-minigame.location    = tracks[Ware_MinigameMode][0]
-endzone_vector      <- tracks[Ware_MinigameMode][1]
-minigame.duration    = tracks[Ware_MinigameMode][2]
+minigame.location    = tracks[mode][0]
+endzone_vector      <- tracks[mode][1]
+minigame.duration    = tracks[mode][2]
 
 function OnPrecache()
 {

--- a/scripts/vscripts/tf2ware_ultimate/minigames/kart.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/kart.nut
@@ -4,6 +4,7 @@ minigame <- Ware_MinigameData
 	author        = ["TonyBaretta", "pokemonPasta"]
 	music         = "moomoofarm"
 	description   = "Race to the End!"
+	modes         = 3
 	end_delay     = 0.5
 	start_freeze  = 0.5
 	allow_damage  = true
@@ -18,15 +19,14 @@ tracks <-
 	["kart_ramp",       Vector(-8000, -6475, -6527), 10.0],
 ]
 
-mode <- RandomInt(0, 2)
 if (Ware_Players.len() > 40)
-	mode = 0
+	Ware_MinigameMode = 0
 
-first <- mode != 2
+first <- Ware_MinigameMode != 2
 
-minigame.location    = tracks[mode][0]
-endzone_vector      <- tracks[mode][1]
-minigame.duration    = tracks[mode][2]
+minigame.location    = tracks[Ware_MinigameMode][0]
+endzone_vector      <- tracks[Ware_MinigameMode][1]
+minigame.duration    = tracks[Ware_MinigameMode][2]
 
 function OnPrecache()
 {

--- a/scripts/vscripts/tf2ware_ultimate/minigames/land_platform.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/land_platform.nut
@@ -1,16 +1,15 @@
 // 0: Iron Bomber
 // 1: Thermal Thruster
 
-mode <- RandomInt(0, 1)
-
 minigame <- Ware_MinigameData
 ({
 	name          = "Land the Platform"
 	author        = ["Gemidyne", "ficool2"]
 	description   = "Land on the platform!"
-	duration      = mode == 0 ? 6.0 : 5.0
+	modes         = 2
+	duration      = Ware_MinigameMode == 0 ? 6.0 : 5.0
 	location      = "factoryplatform"
-	music         = mode == 0 ? "sweetdays" : "surfin"
+	music         = Ware_MinigameMode == 0 ? "sweetdays" : "surfin"
 	max_scale     = 1.0
 	start_freeze  = 0.4
 })
@@ -52,7 +51,7 @@ function OnTeleport(players)
 
 function OnStart()
 {
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		Ware_SetGlobalLoadout(TF_CLASS_DEMOMAN, "Iron Bomber")
 	}

--- a/scripts/vscripts/tf2ware_ultimate/minigames/math.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/math.nut
@@ -8,6 +8,7 @@ minigame <- Ware_MinigameData
 	music           = "question"
 	custom_overlay  = "type_answer"
 	custom_overlay2 = "../chalkboard"
+	modes           = 4
 	suicide_on_end  = true
 })
 
@@ -20,8 +21,7 @@ first <- true
 
 function OnStart()
 {
-	local mode = RandomInt(0, 3)
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		if (RandomInt(0, 49) == 0)
 		{
@@ -37,14 +37,14 @@ function OnStart()
 		answer = a + b
 		operator = "+"
 	}
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 	{
 		a = RandomInt(3, 15)
 		b = RandomInt(3, 15)
 		answer = a - b
 		operator = "-"
 	}
-	else if (mode == 2)
+	else if (Ware_MinigameMode == 2)
 	{
 		a = RandomInt(2, 12)
 		b = RandomInt(2, 12)
@@ -55,7 +55,7 @@ function OnStart()
 		answer = a * b
 		operator = "*"
 	}
-	else if (mode == 3)
+	else if (Ware_MinigameMode == 3)
 	{
 		// always leaves no remainder
 		b = RandomInt(2, 10)

--- a/scripts/vscripts/tf2ware_ultimate/minigames/melee_arena.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/melee_arena.nut
@@ -1,4 +1,3 @@
-mode <- RandomInt(0, 4)
 
 minigame <- Ware_MinigameData
 ({
@@ -11,6 +10,7 @@ minigame <- Ware_MinigameData
 	music          = "keepitup"
 	custom_overlay = "survive"
 	min_players    = 2
+	modes          = 5
 	// small players fly into the air and i have no idea why - pokepasta
 	max_scale      = 1.0
 	start_pass     = true
@@ -29,15 +29,15 @@ minigame <- Ware_MinigameData
 function OnStart()
 {
 	local attributes = { "mod see enemy health" : 1.0 }
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 		Ware_SetGlobalLoadout(TF_CLASS_MEDIC, null, attributes)
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 		Ware_SetGlobalLoadout(TF_CLASS_SCOUT, null, attributes)
-	else if (mode == 2)
+	else if (Ware_MinigameMode == 2)
 		Ware_SetGlobalLoadout(TF_CLASS_PYRO, "Hot Hand", attributes)
-	else if (mode == 3)
+	else if (Ware_MinigameMode == 3)
 		Ware_SetGlobalLoadout(TF_CLASS_SOLDIER, null, attributes)
-	else if (mode == 4)
+	else if (Ware_MinigameMode == 4)
 		Ware_SetGlobalLoadout(TF_CLASS_ENGINEER, "Gunslinger", attributes)
 }
 

--- a/scripts/vscripts/tf2ware_ultimate/minigames/move.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/move.nut
@@ -1,15 +1,15 @@
-mode <- RandomInt(0, 1)
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Move"
 	author         = ["Mecha the Slag", "ficool2"]
-	description    = mode == 0 ? "Move!" : "Don't Move!"
+	modes          = 2
+	description    = Ware_MinigameMode == 0 ? "Move!" : "Don't Move!"
 	duration       = 4.0
 	music          = "actioninsilence"
 	start_pass     = true
 	fail_on_death  = true
-	custom_overlay = mode == 0 ? "move" : "dont_move"
+	custom_overlay = Ware_MinigameMode == 0 ? "move" : "dont_move"
 })
 
 function OnPrecache()
@@ -28,12 +28,12 @@ function OnUpdate()
 		if (!player.IsAlive())
 			continue
 		
-		if (mode == 0)
+		if (Ware_MinigameMode == 0)
 		{
 			if (player.GetAbsVelocity().Length() < 75.0)
 				Ware_SuicidePlayer(player)
 		}
-		else if (mode == 1)
+		else if (Ware_MinigameMode == 1)
 		{
 			if (player.GetAbsVelocity().Length() > 5.0)
 				Ware_SuicidePlayer(player);	

--- a/scripts/vscripts/tf2ware_ultimate/minigames/needle_jump.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/needle_jump.nut
@@ -1,0 +1,38 @@
+minigame <- Ware_MinigameData
+({
+	name           = "Needle Jump"
+	author         = ["Mecha the Slag", "ficool2"]
+	description    = "Needle jump!"
+	duration       = 4.0
+	end_delay      = 1.0
+	max_players    = 40 // generates crazy amount of entities
+	music          = "goodtimes"
+	allow_damage   = true
+})
+
+function OnStart()
+{
+	Ware_SetGlobalLoadout(TF_CLASS_MEDIC, "Syringe Gun")
+}
+
+function OnUpdate()
+{
+	local height = 700.0
+	foreach (player in Ware_MinigamePlayers)
+	{
+		if (!player.IsAlive())
+			continue
+		if (Ware_GetPlayerHeight(player) > height)
+			Ware_PassPlayer(player, true)
+	}
+}
+
+function OnPlayerAttack(player)
+{
+	local dir = player.EyeAngles().Forward()
+	dir.Norm()
+	
+	local dot = dir.Dot(Vector(0, 0, -1.0))
+	if (dot > 0.707) // cos(45)
+		player.SetAbsVelocity(player.GetAbsVelocity() - dir * 88.0 * dot)
+}

--- a/scripts/vscripts/tf2ware_ultimate/minigames/projectile_jump.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/projectile_jump.nut
@@ -1,26 +1,29 @@
+local MODE_ROCKET       = 0
+local MODE_STICKY       = 1
+local MODE_SENTRY       = 2
+local MODE_FLARE        = 3
+local MODE_SHORTCIRCUIT = 4
+
 mode_infos <- 
-[
-	[ "Needle jump!",       "needle_jump",        700.0],
-	[ "Rocket jump!",       "rocket_jump",        384.0],
-	[ "Sticky jump!",       "sticky_jump",        384.0],
-	[ "Sentry jump!",       "sentry_jump",        384.0],
-	[ "Flare jump!",        "flare_jump",         400.0],
-	[ "Short Circuit jump!", "shortcircuit_jump", 384.0],
-]
-// needle jump generates crazy amount of entities
-local min_mode = Ware_Players.len() > 40 ? 1 : 0
-mode <- RandomInt(min_mode, 5)
+{
+	[MODE_ROCKET]       = [ "Rocket jump!",       "rocket_jump",        384.0],
+	[MODE_STICKY]       = [ "Sticky jump!",       "sticky_jump",        384.0],
+	[MODE_SENTRY]       = [ "Sentry jump!",       "sentry_jump",        384.0],
+	[MODE_FLARE]        = [ "Flare jump!",        "flare_jump",         400.0],
+	[MODE_SHORTCIRCUIT] = [ "Short Circuit jump!", "shortcircuit_jump", 384.0],
+}
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Projectile Jump"
 	author         = ["Mecha the Slag", "TonyBaretta", "ficool2"]
-	description    = mode_infos[mode][0]
-	duration       = mode == 3 ? 6.0 : 4.0
-	end_delay      = mode == 3 ? 0.0 : 1.0
+	modes          = mode_infos.len()
+	description    = mode_infos[Ware_MinigameMode][0]
+	duration       = Ware_MinigameMode == MODE_SENTRY ? 6.0 : 4.0
+	end_delay      = Ware_MinigameMode == MODE_SENTRY ? 0.0 : 1.0
 	music          = "goodtimes"
-	custom_overlay = mode_infos[mode][1]
-	allow_damage   = mode == 0 // original ware allowed it, for fun
+	custom_overlay = mode_infos[Ware_MinigameMode][1]
+	allow_damage   = false
 	convars        = 
 	{
 		tf_damageforcescale_self_soldier_badrj = 10
@@ -39,22 +42,17 @@ function OnPrecache()
 function OnStart()
 {
 	local player_class, weapon
-	if (mode == 0)
-	{
-		player_class = TF_CLASS_MEDIC
-		weapon = "Syringe Gun"
-	}
-	else if (mode == 1)
+	if (Ware_MinigameMode == MODE_ROCKET)
 	{
 		player_class = TF_CLASS_SOLDIER
 		weapon = "Rocket Launcher"
 	}
-	else if (mode == 2)
+	else if (Ware_MinigameMode == MODE_STICKY)
 	{
 		player_class = TF_CLASS_DEMOMAN
 		weapon = "Stickybomb Launcher"
 	}
-	else if (mode == 3)
+	else if (Ware_MinigameMode == MODE_SENTRY)
 	{
 		player_class = TF_CLASS_ENGINEER
 		weapon = [ "Construction PDA", "Toolbox", "Wrangler"]
@@ -62,12 +60,12 @@ function OnStart()
 		foreach (player in Ware_MinigamePlayers)
 			Ware_GetPlayerMiniData(player).took_dmgtype <- 0
 	}
-	else if (mode == 4)
+	else if (Ware_MinigameMode == MODE_FLARE)
 	{
 		player_class = TF_CLASS_PYRO
 		weapon = "Detonator"
 	}
-	else if (mode == 5)
+	else if (Ware_MinigameMode == MODE_SHORTCIRCUIT)
 	{
 		player_class = TF_CLASS_ENGINEER
 		weapon = "Short Circuit"
@@ -79,7 +77,7 @@ function OnStart()
 
 function OnUpdate()
 {
-	local height = mode_infos[mode][2]
+	local height = mode_infos[Ware_MinigameMode][2]
 	foreach (player in Ware_MinigamePlayers)
 	{
 		if (!player.IsAlive())
@@ -88,7 +86,7 @@ function OnUpdate()
 			Ware_PassPlayer(player, true)
 	}
 	
-	if (mode == 5)
+	if (Ware_MinigameMode == MODE_SHORTCIRCUIT)
 	{
 		local dead_orbs = {}
 		foreach (orb, data in orbs)
@@ -136,7 +134,7 @@ function OnUpdate()
 
 function OnEnd()
 {
-	if (mode == 3)
+	if (Ware_MinigameMode == MODE_SENTRY)
 	{
 		foreach (player in Ware_MinigamePlayers)
 		{
@@ -148,19 +146,7 @@ function OnEnd()
 	}
 }
 
-if (mode == 0)
-{
-	function OnPlayerAttack(player)
-	{
-		local dir = player.EyeAngles().Forward()
-		dir.Norm()
-		
-		local dot = dir.Dot(Vector(0, 0, -1.0))
-		if (dot > 0.707) // cos(45)
-			player.SetAbsVelocity(player.GetAbsVelocity() - dir * 88.0 * dot)
-	}
-}
-else if (mode == 3)
+if (Ware_MinigameMode == MODE_SENTRY)
 {
 	function OnTakeDamage(params)
 	{
@@ -180,7 +166,7 @@ else if (mode == 3)
 		SetPropInt(building, "m_nDefaultUpgradeLevel", 2)
 	}	
 }
-else if (mode == 5)
+else if (Ware_MinigameMode == MODE_SHORTCIRCUIT)
 {
 	function OnTakeDamage(params)
 	{

--- a/scripts/vscripts/tf2ware_ultimate/minigames/projectile_jump.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/projectile_jump.nut
@@ -7,20 +7,18 @@ mode_infos <-
 	[ "Flare jump!",        "flare_jump",         400.0],
 	[ "Short Circuit jump!", "shortcircuit_jump", 384.0],
 ]
-// needle jump generates crazy amount of entities
-local min_mode = Ware_Players.len() > 40 ? 1 : 0
-mode <- RandomInt(min_mode, 5)
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Projectile Jump"
 	author         = ["Mecha the Slag", "TonyBaretta", "ficool2"]
-	description    = mode_infos[mode][0]
-	duration       = mode == 3 ? 6.0 : 4.0
-	end_delay      = mode == 3 ? 0.0 : 1.0
+	modes          = 6
+	description    = mode_infos[Ware_MinigameMode][0]
+	duration       = Ware_MinigameMode == 3 ? 6.0 : 4.0
+	end_delay      = Ware_MinigameMode == 3 ? 0.0 : 1.0
 	music          = "goodtimes"
-	custom_overlay = mode_infos[mode][1]
-	allow_damage   = mode == 0 // original ware allowed it, for fun
+	custom_overlay = mode_infos[Ware_MinigameMode][1]
+	allow_damage   = Ware_MinigameMode == 0 // original ware allowed it, for fun
 	convars        = 
 	{
 		tf_damageforcescale_self_soldier_badrj = 10
@@ -38,23 +36,28 @@ function OnPrecache()
 
 function OnStart()
 {
+	// needle jump generates crazy amount of entities
+	// TODO: This doesn't work with new mode system!!! Overlay and description are already set. Need an alternate way of disallowing modes
+	if(Ware_Players.len() > 40 && Ware_MinigameMode == 0)
+		Ware_MinigameMode = RandomInt(1, minigame.modes - 1)
+	
 	local player_class, weapon
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		player_class = TF_CLASS_MEDIC
 		weapon = "Syringe Gun"
 	}
-	else if (mode == 1)
+	else if (Ware_MinigameMode == 1)
 	{
 		player_class = TF_CLASS_SOLDIER
 		weapon = "Rocket Launcher"
 	}
-	else if (mode == 2)
+	else if (Ware_MinigameMode == 2)
 	{
 		player_class = TF_CLASS_DEMOMAN
 		weapon = "Stickybomb Launcher"
 	}
-	else if (mode == 3)
+	else if (Ware_MinigameMode == 3)
 	{
 		player_class = TF_CLASS_ENGINEER
 		weapon = [ "Construction PDA", "Toolbox", "Wrangler"]
@@ -62,12 +65,12 @@ function OnStart()
 		foreach (player in Ware_MinigamePlayers)
 			Ware_GetPlayerMiniData(player).took_dmgtype <- 0
 	}
-	else if (mode == 4)
+	else if (Ware_MinigameMode == 4)
 	{
 		player_class = TF_CLASS_PYRO
 		weapon = "Detonator"
 	}
-	else if (mode == 5)
+	else if (Ware_MinigameMode == 5)
 	{
 		player_class = TF_CLASS_ENGINEER
 		weapon = "Short Circuit"
@@ -79,7 +82,7 @@ function OnStart()
 
 function OnUpdate()
 {
-	local height = mode_infos[mode][2]
+	local height = mode_infos[Ware_MinigameMode][2]
 	foreach (player in Ware_MinigamePlayers)
 	{
 		if (!player.IsAlive())
@@ -88,7 +91,7 @@ function OnUpdate()
 			Ware_PassPlayer(player, true)
 	}
 	
-	if (mode == 5)
+	if (Ware_MinigameMode == 5)
 	{
 		local dead_orbs = {}
 		foreach (orb, data in orbs)
@@ -136,7 +139,7 @@ function OnUpdate()
 
 function OnEnd()
 {
-	if (mode == 3)
+	if (Ware_MinigameMode == 3)
 	{
 		foreach (player in Ware_MinigamePlayers)
 		{
@@ -148,7 +151,7 @@ function OnEnd()
 	}
 }
 
-if (mode == 0)
+if (Ware_MinigameMode == 0)
 {
 	function OnPlayerAttack(player)
 	{
@@ -160,7 +163,7 @@ if (mode == 0)
 			player.SetAbsVelocity(player.GetAbsVelocity() - dir * 88.0 * dot)
 	}
 }
-else if (mode == 3)
+else if (Ware_MinigameMode == 3)
 {
 	function OnTakeDamage(params)
 	{
@@ -180,7 +183,7 @@ else if (mode == 3)
 		SetPropInt(building, "m_nDefaultUpgradeLevel", 2)
 	}	
 }
-else if (mode == 5)
+else if (Ware_MinigameMode == 5)
 {
 	function OnTakeDamage(params)
 	{

--- a/scripts/vscripts/tf2ware_ultimate/minigames/projectile_jump.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/projectile_jump.nut
@@ -7,18 +7,20 @@ mode_infos <-
 	[ "Flare jump!",        "flare_jump",         400.0],
 	[ "Short Circuit jump!", "shortcircuit_jump", 384.0],
 ]
+// needle jump generates crazy amount of entities
+local min_mode = Ware_Players.len() > 40 ? 1 : 0
+mode <- RandomInt(min_mode, 5)
 
 minigame <- Ware_MinigameData
 ({
 	name           = "Projectile Jump"
 	author         = ["Mecha the Slag", "TonyBaretta", "ficool2"]
-	modes          = 6
-	description    = mode_infos[Ware_MinigameMode][0]
-	duration       = Ware_MinigameMode == 3 ? 6.0 : 4.0
-	end_delay      = Ware_MinigameMode == 3 ? 0.0 : 1.0
+	description    = mode_infos[mode][0]
+	duration       = mode == 3 ? 6.0 : 4.0
+	end_delay      = mode == 3 ? 0.0 : 1.0
 	music          = "goodtimes"
-	custom_overlay = mode_infos[Ware_MinigameMode][1]
-	allow_damage   = Ware_MinigameMode == 0 // original ware allowed it, for fun
+	custom_overlay = mode_infos[mode][1]
+	allow_damage   = mode == 0 // original ware allowed it, for fun
 	convars        = 
 	{
 		tf_damageforcescale_self_soldier_badrj = 10
@@ -36,28 +38,23 @@ function OnPrecache()
 
 function OnStart()
 {
-	// needle jump generates crazy amount of entities
-	// TODO: This doesn't work with new mode system!!! Overlay and description are already set. Need an alternate way of disallowing modes
-	if(Ware_Players.len() > 40 && Ware_MinigameMode == 0)
-		Ware_MinigameMode = RandomInt(1, minigame.modes - 1)
-	
 	local player_class, weapon
-	if (Ware_MinigameMode == 0)
+	if (mode == 0)
 	{
 		player_class = TF_CLASS_MEDIC
 		weapon = "Syringe Gun"
 	}
-	else if (Ware_MinigameMode == 1)
+	else if (mode == 1)
 	{
 		player_class = TF_CLASS_SOLDIER
 		weapon = "Rocket Launcher"
 	}
-	else if (Ware_MinigameMode == 2)
+	else if (mode == 2)
 	{
 		player_class = TF_CLASS_DEMOMAN
 		weapon = "Stickybomb Launcher"
 	}
-	else if (Ware_MinigameMode == 3)
+	else if (mode == 3)
 	{
 		player_class = TF_CLASS_ENGINEER
 		weapon = [ "Construction PDA", "Toolbox", "Wrangler"]
@@ -65,12 +62,12 @@ function OnStart()
 		foreach (player in Ware_MinigamePlayers)
 			Ware_GetPlayerMiniData(player).took_dmgtype <- 0
 	}
-	else if (Ware_MinigameMode == 4)
+	else if (mode == 4)
 	{
 		player_class = TF_CLASS_PYRO
 		weapon = "Detonator"
 	}
-	else if (Ware_MinigameMode == 5)
+	else if (mode == 5)
 	{
 		player_class = TF_CLASS_ENGINEER
 		weapon = "Short Circuit"
@@ -82,7 +79,7 @@ function OnStart()
 
 function OnUpdate()
 {
-	local height = mode_infos[Ware_MinigameMode][2]
+	local height = mode_infos[mode][2]
 	foreach (player in Ware_MinigamePlayers)
 	{
 		if (!player.IsAlive())
@@ -91,7 +88,7 @@ function OnUpdate()
 			Ware_PassPlayer(player, true)
 	}
 	
-	if (Ware_MinigameMode == 5)
+	if (mode == 5)
 	{
 		local dead_orbs = {}
 		foreach (orb, data in orbs)
@@ -139,7 +136,7 @@ function OnUpdate()
 
 function OnEnd()
 {
-	if (Ware_MinigameMode == 3)
+	if (mode == 3)
 	{
 		foreach (player in Ware_MinigamePlayers)
 		{
@@ -151,7 +148,7 @@ function OnEnd()
 	}
 }
 
-if (Ware_MinigameMode == 0)
+if (mode == 0)
 {
 	function OnPlayerAttack(player)
 	{
@@ -163,7 +160,7 @@ if (Ware_MinigameMode == 0)
 			player.SetAbsVelocity(player.GetAbsVelocity() - dir * 88.0 * dot)
 	}
 }
-else if (Ware_MinigameMode == 3)
+else if (mode == 3)
 {
 	function OnTakeDamage(params)
 	{
@@ -183,7 +180,7 @@ else if (Ware_MinigameMode == 3)
 		SetPropInt(building, "m_nDefaultUpgradeLevel", 2)
 	}	
 }
-else if (Ware_MinigameMode == 5)
+else if (mode == 5)
 {
 	function OnTakeDamage(params)
 	{

--- a/scripts/vscripts/tf2ware_ultimate/minigames/simon_says.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/simon_says.nut
@@ -1,5 +1,4 @@
 simon    <- RandomInt(0, 1)
-mode     <- RandomInt(0, 9)
 suffixes <- ["Taunt", "Jump", "Crouch", "Medic", "Eat", "Drink", "Inspect", "Horn", "Type", "Charge"]
 
 minigame <- Ware_MinigameData
@@ -9,9 +8,10 @@ minigame <- Ware_MinigameData
 	description    = "Simon says..."
 	duration       = 4.0
 	music          = "clumsy"
+	modes          = 10
 	start_pass     = simon == 0
-	custom_overlay = format("%s_says_%s", simon ? "simon" : "someone", suffixes[mode].tolower())
-	description    = format("%s says %s!", simon ? "Simon" : "Someone", suffixes[mode])
+	custom_overlay = format("%s_says_%s", simon ? "simon" : "someone", suffixes[Ware_MinigameMode].tolower())
+	description    = format("%s says %s!", simon ? "Simon" : "Someone", suffixes[Ware_MinigameMode])
 })
 
 function OnPrecache()
@@ -27,21 +27,21 @@ function OnPrecache()
 
 function OnStart()
 {
-	if (mode == 4)
+	if (Ware_MinigameMode == 4)
 	{
 		local items = ["Sandvich", "Dalokohs Bar", "Fishcake", "Buffalo Steak Sandvich", "Second Banana"]
 		Ware_SetGlobalLoadout(TF_CLASS_HEAVYWEAPONS, RandomElement(items))
 	}
-	else if (mode == 5)
+	else if (Ware_MinigameMode == 5)
 	{
 		local items = ["Bonk! Atomic Punch", "Crit-a-Cola"]
 		Ware_SetGlobalLoadout(TF_CLASS_SCOUT, RandomElement(items))
 	}
-	else if (mode == 7)
+	else if (Ware_MinigameMode == 7)
 	{
 		Ware_SetGlobalCondition(TF_COND_HALLOWEEN_KART)
 	}
-	else if (mode == 9)
+	else if (Ware_MinigameMode == 9)
 	{ 
 		foreach (player in Ware_MinigamePlayers)
 		{
@@ -59,7 +59,7 @@ function PassOrFailPlayer(player, pass)
 		Ware_ShowScreenOverlay(player, "hud/tf2ware_ultimate/minigames/simon_says_fail")
 }
 	
-if (mode == 3 || mode == 4 || mode == 5)
+if (Ware_MinigameMode == 3 || Ware_MinigameMode == 4 || Ware_MinigameMode == 5)
 {
 	function OnPlayerVoiceline(player, voiceline)
 	{
@@ -67,7 +67,7 @@ if (mode == 3 || mode == 4 || mode == 5)
 		if (Ware_IsPlayerPassed(player) != pass)
 			return
 			
-		if (mode == 5)
+		if (Ware_MinigameMode == 5)
 		{
 			if (voiceline.find("taunt04") != null)
 				PassOrFailPlayer(player, !pass)
@@ -76,12 +76,12 @@ if (mode == 3 || mode == 4 || mode == 5)
 		{
 			if (voiceline in VCD_MAP)
 			{
-				if (mode == 3)
+				if (Ware_MinigameMode == 3)
 				{				
 					if (VCD_MAP[voiceline].find(".Medic") != null)
 						PassOrFailPlayer(player, !pass)
 				}
-				else if (mode == 4)
+				else if (Ware_MinigameMode == 4)
 				{
 					if (VCD_MAP[voiceline] == "Heavy.SandwichEat")
 						PassOrFailPlayer(player, !pass)
@@ -90,7 +90,7 @@ if (mode == 3 || mode == 4 || mode == 5)
 		}
 	}
 }
-else if (mode == 7)
+else if (Ware_MinigameMode == 7)
 {
 	function OnPlayerHorn(player)
 	{
@@ -98,7 +98,7 @@ else if (mode == 7)
 		PassOrFailPlayer(player, !pass)
 	}
 }
-else if (mode == 8)
+else if (Ware_MinigameMode == 8)
 {
 	function OnPlayerSay(player, text)
 	{
@@ -106,7 +106,7 @@ else if (mode == 8)
 		PassOrFailPlayer(player, !pass)
 	}
 }
-else if (mode == 9)
+else if (Ware_MinigameMode == 9)
 {
 	// TODO: Prevent charge spam after initial charge
 	local pass = simon == 0
@@ -138,22 +138,22 @@ else
 			if (Ware_IsPlayerPassed(player) != pass)
 				continue
 				
-			if (mode == 0)
+			if (Ware_MinigameMode == 0)
 			{
 				if (player.IsTaunting())
 					PassOrFailPlayer(player, !pass)
 			}
-			else if (mode == 1)
+			else if (Ware_MinigameMode == 1)
 			{
 				if (GetPropBool(player, "m_Shared.m_bJumping"))
 					PassOrFailPlayer(player, !pass)
 			}
-			else if (mode == 2)
+			else if (Ware_MinigameMode == 2)
 			{
 				if (player.GetFlags() & FL_DUCKING)
 					PassOrFailPlayer(player, !pass)
 			}	
-			else if (mode == 6)
+			else if (Ware_MinigameMode == 6)
 			{
 				local weapon = player.GetActiveWeapon()
 				if (weapon && GetPropInt(weapon, "m_nInspectStage") >= 0)
@@ -165,7 +165,7 @@ else
 
 function OnEnd()
 {
-	if (mode == 4 || mode == 5)
+	if (Ware_MinigameMode == 4 || Ware_MinigameMode == 5)
 	{
 		foreach (player in Ware_MinigamePlayers)
 		{

--- a/scripts/vscripts/tf2ware_ultimate/minigames/stand_near.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/stand_near.nut
@@ -1,10 +1,10 @@
-mode <- RandomInt(0, 1)
-	
+
 minigame <- Ware_MinigameData
 ({
 	name           = "Stand Near"
 	author         = ["sasch", "ficool2"]
-	description    = mode == 1 ? "Don't stand near anybody!" : "Stand near somebody!"
+	modes          = 2
+	description    = Ware_MinigameMode == 1 ? "Don't stand near anybody!" : "Stand near somebody!"
 	duration       = 4.0
 	end_delay      = 1.0
 	music          = "spotlightsonyou"
@@ -12,7 +12,7 @@ minigame <- Ware_MinigameData
 	start_pass     = true
 	allow_damage   = true
 	fail_on_death  = true
-	custom_overlay = mode == 1 ? "stand_away" : "stand_near"
+	custom_overlay = Ware_MinigameMode == 1 ? "stand_away" : "stand_near"
 })
 
 function OnPrecache()
@@ -47,7 +47,7 @@ function OnEnd()
 			local dist = VectorDistance(target1.origin, target2.origin)
 			if (dist < threshold)
 			{
-				if (mode == 1)
+				if (Ware_MinigameMode == 1)
 					target1.player.TakeDamage(1000.0, DMG_BLAST, target2.player)
 				else
 					target1.kill = false
@@ -56,7 +56,7 @@ function OnEnd()
 		}
 	}
 	
-	if (mode == 0)
+	if (Ware_MinigameMode == 0)
 	{
 		foreach (target in targets)
 		{


### PR DESCRIPTION
This PR will formalise the "modes" system used in some minigames to a minigame parameter for number of modes, and a global variable for current mode. This allows us to declare the current mode which will be helpful for troubleshooting, and will also allow for setting certain modes and weighing moded minigames more in rotation, which is helpful for Simon Says and Projectile Jump in particular, as individual modes don't come up too often at the moment.

KNOWN ISSUES:
- Minigames that disallow certain modes sometimes (needle jump and kart tracks on high player count) do not work with this system yet

TODO:
- [x] Initial setup (variable, param and logic)
- [x] Convert minigames
- [x] Add commands
- [x] Add "weight" system (Ware_Minigames or Ware_MinigameRotation?)