### PR TITLE
Add No Text special round

### DIFF
--- a/cfg/tf2ware_ultimate/specialrounds.cfg
+++ b/cfg/tf2ware_ultimate/specialrounds.cfg
@@ -19,6 +19,7 @@ math_only
 merasmus
 mirrored_world
 no_movingback
+no_text
 non_stop
 nostalgia
 opposite_day

--- a/scripts/vscripts/tf2ware_ultimate/default/specialrounds.nut
+++ b/scripts/vscripts/tf2ware_ultimate/default/specialrounds.nut
@@ -21,6 +21,7 @@ math_only
 merasmus
 mirrored_world
 no_movingback
+no_text
 non_stop
 nostalgia
 opposite_day

--- a/scripts/vscripts/tf2ware_ultimate/specialrounds/no_text.nut
+++ b/scripts/vscripts/tf2ware_ultimate/specialrounds/no_text.nut
@@ -1,0 +1,65 @@
+text_mgr <- null
+
+special_round <- Ware_SpecialRoundData
+({
+	name = "No Text"
+	author = "42"
+	description = "We refuse to elaborate what you need to do."
+	category = ""
+})
+
+function OnStart()
+{
+	// hack to prevent hud texts being shown
+	Ware_TextManager.KeyValueFromInt("effect", 2)
+	Ware_TextManager.KeyValueFromFloat("fxtime", 999999999.0)
+}
+
+function OnEnd()
+{
+	Ware_TextManager.KeyValueFromInt("effect", 0)
+	Ware_TextManager.KeyValueFromFloat("fxtime", 0.0)
+}
+
+function OnMinigameStart()
+{
+	ClearTexts()
+}
+
+function OnMinigameEnd()
+{
+	ClearTexts()
+	
+	if (typeof(Ware_Minigame.description) != "array")
+	{
+		Ware_ChatPrint(null, "The minigame was {color}{str}", COLOR_GREEN, Ware_Minigame.description)
+	}
+	else
+	{
+		foreach (player in Ware_MinigamePlayers)
+			Ware_ChatPrint(player, "The minigame was {color}{str}", COLOR_GREEN, Ware_Minigame.description[Ware_GetPlayerMission(player)])
+	}
+}
+
+function OnSpeedup()
+{
+	ClearTexts()
+}
+
+function OnUpdate()
+{
+	ClearTexts()
+}
+
+function ClearTexts()
+{
+	foreach (player in Ware_MinigamePlayers)
+		player.SetScriptOverlayMaterial("")
+	
+	if (Ware_Minigame != null)
+	{
+		local annotations = Ware_Minigame.annotations
+		for (local i = annotations.len() - 1; i >= 0; i--)
+			Ware_HideAnnotation(annotations[i])
+	}
+}


### PR DESCRIPTION
We refuse to elaborate what you need to do.

Currently this prevents any overlays, game_text, and annotation texts being displayed. After the minigame ends, it's description is printed to the chat for players to find out what they should've done.

First went for an approach to avoid adding any extra code outside of `no_text.nut`, but we may still need to add callbacks if want to solve some current issues:

- Overlays can still appear for a frame from "Speed Up", "Bossgame", before disappearing.
- Hiding game_text also includes the "Special Round" list at the left and non-text related thing, e.g. "X" on hitting something.
- Text chat left unchanged, would like to also hide some messages, e.g. "TIP", "Reached the end first".

Open to whenever to show/hide any specific texts/areas, or whenever to use variable/callbacks to solve some bugs.