### PR TITLE
Add theme authors to credits

### DIFF
--- a/cfg/tf2ware_ultimate/themes.cfg
+++ b/cfg/tf2ware_ultimate/themes.cfg
@@ -1,6 +1,7 @@
 {
 	theme_name = "_default"
 	visual_name = "TF2Ware Ultimate"
+	author = ["pokemonPasta", "ficool2", "Mecha the Slag"]
 	sounds = 
 	{
 		// if any are 0.0 they arent used for intermission timings yet
@@ -22,6 +23,7 @@
 {
 	theme_name = "_tf2ware_classic"
 	visual_name = "TF2Ware Classic" // one of the OG slagware themes, this one seems to be original to tf2ware.
+	author = "Mecha the Slag" // TODO: who actually made this?
 	sounds = 
 	{
 		"failure": 2.377
@@ -33,6 +35,7 @@
 {
 	theme_name = "3ds_ashley"
 	visual_name = "Ashley (3DS)"
+	author = "pokemonPasta"
 	sounds = 
 	{
 		"failure": 1.968
@@ -44,6 +47,7 @@
 {
 	theme_name = "3ds_jimmyt"
 	visual_name = "Jimmy T. (3DS)"
+	author = "pokemonPasta"
 	sounds = 
 	{
 		"failure": 2.08
@@ -98,6 +102,7 @@
 {
 	theme_name = "ds_diy_warioman" // from DIY showcase, should that be counted separately?
 	visual_name = "Wario-Man (WiiWare - D.I.Y. Showcase)" // another of the classic tf2ware themes, this is one of the ones used in tonyware
+	author = "TonyBaretta"
 	sounds = 
 	{
 		"boss":     4.004
@@ -181,6 +186,7 @@
 {
 	theme_name = "wii_9volt"
 	visual_name = "9-Volt (Wii)"
+	author = "pokemonPasta"
 	sounds = 
 	{
 		"failure": 2.013
@@ -192,6 +198,7 @@
 {
 	theme_name = "wii_18volt"
 	visual_name = "18-Volt (Wii)" // this is just the 9volt intro cutscene, but it's a tonyware classic. dunno what else to call it.
+	author = "TonyBaretta"
 	sounds = 
 	{
 		"failure":  2.005

--- a/cfg/tf2ware_ultimate/themes.cfg
+++ b/cfg/tf2ware_ultimate/themes.cfg
@@ -59,6 +59,7 @@
 {
 	theme_name = "ds_diy_orbulon"
 	visual_name = "Orbulon (DS - D.I.Y.)"
+	author = "Gemidyne"
 	sounds = 
 	{
 		"boss":     4.119
@@ -73,6 +74,7 @@
 {
 	theme_name = "ds_diy_shuffle"
 	visual_name = "Shuffle (WiiWare - D.I.Y. Showcase)"
+	author = "Gemidyne"
 	sounds = 
 	{
 		"boss":     4.008
@@ -117,6 +119,7 @@
 {
 	theme_name = "ds_touched_jimmyt"
 	visual_name = "Jimmy T. (DS - Touched!)"
+	author = "Gemidyne"
 	sounds = 
 	{
 		"failure": 2.1
@@ -140,6 +143,7 @@
 {
 	theme_name = "ds_touched_wario"
 	visual_name = "Wario (DS - Touched!)"
+	author = "Gemidyne"
 	sounds = 
 	{
 		"failure": 2.003
@@ -151,6 +155,7 @@
 {
 	theme_name = "ds_touched_warioman"
 	visual_name = "Wario-Man (DS - Touched!)"
+	author = "Gemidyne"
 	sounds = 
 	{
 		"failure": 1.977
@@ -211,6 +216,7 @@
 {
 	theme_name = "wii_katandana"
 	visual_name = "Kat & Ana (Wii)"
+	author = "pokemonPasta"
 	sounds = 
 	{
 		"failure": 2.00
@@ -222,6 +228,7 @@
 {
 	theme_name = "wii_mona"
 	visual_name = "Mona (Wii)"
+	author = "Gemidyne"
 	sounds = 
 	{
 		"failure": 2.000

--- a/scripts/vscripts/tf2ware_ultimate/default/themes.nut
+++ b/scripts/vscripts/tf2ware_ultimate/default/themes.nut
@@ -3,6 +3,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""_default""
 	visual_name = ""TF2Ware Ultimate""
+	author = [""pokemonPasta"", ""ficool2"", ""Mecha the Slag""]
 	sounds = 
 	{
 		// if any are 0.0 they arent used for intermission timings yet
@@ -24,6 +25,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""_tf2ware_classic""
 	visual_name = ""TF2Ware Classic"" // one of the OG slagware themes, this one seems to be original to tf2ware.
+	author = ""Mecha the Slag"" // TODO: who actually made this?
 	sounds = 
 	{
 		""failure"": 2.377
@@ -35,6 +37,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""3ds_ashley""
 	visual_name = ""Ashley (3DS)""
+	author = ""pokemonPasta""
 	sounds = 
 	{
 		""failure"": 1.968
@@ -46,6 +49,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""3ds_jimmyt""
 	visual_name = ""Jimmy T. (3DS)""
+	author = ""pokemonPasta""
 	sounds = 
 	{
 		""failure"": 2.08
@@ -57,6 +61,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""ds_diy_orbulon""
 	visual_name = ""Orbulon (DS - D.I.Y.)""
+	author = ""Gemidyne""
 	sounds = 
 	{
 		""boss"":     4.119
@@ -71,6 +76,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""ds_diy_shuffle""
 	visual_name = ""Shuffle (WiiWare - D.I.Y. Showcase)""
+	author = ""Gemidyne""
 	sounds = 
 	{
 		""boss"":     4.008
@@ -100,6 +106,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""ds_diy_warioman"" // from DIY showcase, should that be counted separately?
 	visual_name = ""Wario-Man (WiiWare - D.I.Y. Showcase)"" // another of the classic tf2ware themes, this is one of the ones used in tonyware
+	author = ""TonyBaretta""
 	sounds = 
 	{
 		""boss"":     4.004
@@ -114,6 +121,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""ds_touched_jimmyt""
 	visual_name = ""Jimmy T. (DS - Touched!)""
+	author = ""Gemidyne""
 	sounds = 
 	{
 		""failure"": 2.1
@@ -137,6 +145,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""ds_touched_wario""
 	visual_name = ""Wario (DS - Touched!)""
+	author = ""Gemidyne""
 	sounds = 
 	{
 		""failure"": 2.003
@@ -148,6 +157,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""ds_touched_warioman""
 	visual_name = ""Wario-Man (DS - Touched!)""
+	author = ""Gemidyne""
 	sounds = 
 	{
 		""failure"": 1.977
@@ -183,6 +193,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""wii_9volt""
 	visual_name = ""9-Volt (Wii)""
+	author = ""pokemonPasta""
 	sounds = 
 	{
 		""failure"": 2.013
@@ -194,6 +205,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""wii_18volt""
 	visual_name = ""18-Volt (Wii)"" // this is just the 9volt intro cutscene, but it's a tonyware classic. dunno what else to call it.
+	author = ""TonyBaretta""
 	sounds = 
 	{
 		""failure"":  2.005
@@ -206,6 +218,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""wii_katandana""
 	visual_name = ""Kat & Ana (Wii)""
+	author = ""pokemonPasta""
 	sounds = 
 	{
 		""failure"": 2.00
@@ -217,6 +230,7 @@ buffer<-@"VERSION 4
 {
 	theme_name = ""wii_mona""
 	visual_name = ""Mona (Wii)""
+	author = ""Gemidyne""
 	sounds = 
 	{
 		""failure"": 2.000

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -313,7 +313,7 @@ function Ware_PrecacheNext()
 	local authors = {}
 	local music_minigame = {}, music_bossgame = {}
 
-	local add_author = function(author, folder)
+	local AddAuthor = function(author, folder)
 	{
 		local list = author
 		if (typeof(list) != "array")
@@ -377,7 +377,7 @@ function Ware_PrecacheNext()
 					PrecacheOverlay(overlay)
 			}
 			
-			add_author(minigame.author, folder)
+			AddAuthor(minigame.author, folder)
 			
 			if (minigame.music)
 			{
@@ -411,7 +411,7 @@ function Ware_PrecacheNext()
 				Ware_Error("Special round '%s' has no category entry", name)
 			}
 			
-			add_author(scope.special_round.author, folder)
+			AddAuthor(scope.special_round.author, folder)
 		}
 
 		return true
@@ -435,7 +435,7 @@ function Ware_PrecacheNext()
 	
 	foreach (theme in Ware_Themes)
 	{
-		add_author(theme.author, "themes")
+		AddAuthor(theme.author, "themes")
 		foreach (key, value in theme.sounds)
 			PrecacheSound(format("tf2ware_ultimate/v%d/music_game/%s/%s.mp3", WARE_MP3_VERSION, theme.theme_name, key))
 	}

--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -239,7 +239,6 @@ if (!("Ware_Precached" in this))
 		"PigeonVerde"      : ["TF2Ware v2 map"],
 		// authors from minigames and special rounds are added automatically
 	}
-	Ware_ExtraAuthors             <- {}
 
 	// this shuts up incursion distance warnings from the nav mesh
 	CreateEntitySafe("base_boss").KeyValueFromString("classname", "point_commentary_viewpoint")
@@ -308,6 +307,7 @@ function Ware_UpdateNav()
 	}
 }
 
+local extra_authors = {}
 function Ware_AddAuthor(authors, folder)
 {
 	local list = authors
@@ -316,9 +316,9 @@ function Ware_AddAuthor(authors, folder)
 	
 	foreach (author in list)
 	{
-		if (!(author in Ware_ExtraAuthors))
+		if (!(author in extra_authors))
 		{
-			Ware_ExtraAuthors[author] <-
+			extra_authors[author] <-
 			{
 				minigames     = 0
 				bossgames     = 0
@@ -327,7 +327,7 @@ function Ware_AddAuthor(authors, folder)
 			}
 		}
 			
-		Ware_ExtraAuthors[author][folder]++
+		extra_authors[author][folder]++
 	}
 }
 
@@ -453,8 +453,7 @@ function Ware_PrecacheNext()
 foreach(theme in Ware_Themes)
 	Ware_AddAuthor(theme.author, "themes") // no null check, gonna assume themes have authors (add to all missing in later commit)
 
-// move all Ware_ExtraAuthors to Ware_Authors. should Ware_ExtraAuthors be deleted in some way after? maybe should be local in the first place
-foreach (author, credits in Ware_ExtraAuthors)
+foreach (author, credits in extra_authors)
 {
 	if (!(author in Ware_Authors))
 		Ware_Authors[author] <- []


### PR DESCRIPTION
This PR adds the `author` key to all themes and folds it into the crediting system. Note that internal themes do not use the `author` key.

Apologies for the odd commit history, I overcomplicated this one initially.