### PR TITLE
Add Taunt: Texan Trickshot to "Taunt Kill!" minigame

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/items.nut
+++ b/scripts/vscripts/tf2ware_ultimate/items.nut
@@ -1229,4 +1229,9 @@ ITEM_MAP <-
         id = 30758
         classname = "saxxy"
     }
+	"Taunt: Texan Trickshot":
+    {
+        id = 31520
+        classname = "tf_weapon_revolver"
+    }
 }

--- a/scripts/vscripts/tf2ware_ultimate/minigames/taunt_kill.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/taunt_kill.nut
@@ -44,18 +44,19 @@ function OnStart()
 {
 	local loadouts =
 	[
-		[ TF_CLASS_SCOUT,        "Sandman"          , @(player) SuicideLine(player, 64.0)    ],
-		[ TF_CLASS_SOLDIER,      "Equalizer"        , @(player) SuicideSphere(player, 100.0) ],
-		[ TF_CLASS_PYRO,         "Flare Gun"        , @(player) SuicideLine(player, 64.0)    ],
-		[ TF_CLASS_PYRO,         "Rainblower"       , @(player) SuicideSphere(player, 100.0) ],
-		[ TF_CLASS_PYRO,         "Scorch Shot"      , @(player) SuicideLine(player, 128.0)   ],
-		[ TF_CLASS_DEMOMAN,      "Eyelander"        , @(player) SuicideLine(player, 128.0)   ],
-		[ TF_CLASS_HEAVYWEAPONS, "Fists"            , @(player) SuicideLine(player, 500.0)   ],
-		[ TF_CLASS_ENGINEER,     "Frontier Justice" , @(player) SuicideLine(player, 128.0)   ],
-		[ TF_CLASS_ENGINEER,     "Gunslinger"       , @(player) SuicideLine(player, 128.0)   ],
-		[ TF_CLASS_MEDIC,        "Ubersaw"          , @(player) SuicideLine(player, 128.0)   ],
-		[ TF_CLASS_SNIPER,       "Huntsman"         , @(player) SuicideLine(player, 128.0)   ],
-		[ TF_CLASS_SPY,          "Knife"            , @(player) SuicideLine(player, 64.0)    ],
+		[ TF_CLASS_SCOUT,        "Sandman"          	  , @(player) SuicideLine(player, 64.0)    ],
+		[ TF_CLASS_SOLDIER,      "Equalizer"        	  , @(player) SuicideSphere(player, 100.0) ],
+		[ TF_CLASS_PYRO,         "Flare Gun"        	  , @(player) SuicideLine(player, 64.0)    ],
+		[ TF_CLASS_PYRO,         "Rainblower"       	  , @(player) SuicideSphere(player, 100.0) ],
+		[ TF_CLASS_PYRO,         "Scorch Shot"      	  , @(player) SuicideLine(player, 128.0)   ],
+		[ TF_CLASS_DEMOMAN,      "Eyelander"        	  , @(player) SuicideLine(player, 128.0)   ],
+		[ TF_CLASS_HEAVYWEAPONS, "Fists"            	  , @(player) SuicideLine(player, 500.0)   ],
+		[ TF_CLASS_ENGINEER,     "Frontier Justice" 	  , @(player) SuicideLine(player, 128.0)   ],
+		[ TF_CLASS_ENGINEER,     "Gunslinger"       	  , @(player) SuicideLine(player, 128.0)   ],
+		[ TF_CLASS_ENGINEER,     "Taunt: Texan Trickshot" , @(player) SuicideLine(player, 500.0)   ],
+		[ TF_CLASS_MEDIC,        "Ubersaw"          	  , @(player) SuicideLine(player, 128.0)   ],
+		[ TF_CLASS_SNIPER,       "Huntsman"         	  , @(player) SuicideLine(player, 128.0)   ],
+		[ TF_CLASS_SPY,          "Knife"            	  , @(player) SuicideLine(player, 64.0)    ],
 	]
 	local loadout = RandomElement(loadouts)
 	


### PR DESCRIPTION
This uses a tiny hack that may not be acceptable for being merged, but I think it's realistically fine and hasn't caused any issues for me:
- I add an entry into items.nut with a classname of tf_weapon_revolver* and an id of 31520 (the taunt's item id)

Video demonstrating the minigame is attached below:

https://github.com/user-attachments/assets/7b87a4c9-628c-4970-b6ff-947aa7f1a4e0

* maybe bat would be better since it's kinda the "weapon zero" but it wouldn't _really_ change anything except for the idle animation the engineer has