### PR TITLE
Always remove picked minigames from rotation

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/main.nut
+++ b/scripts/vscripts/tf2ware_ultimate/main.nut
@@ -1612,20 +1612,17 @@ function Ware_StartMinigameInternal(is_boss)
 			Ware_MinigameMode = 0	
 		}
 		
+		if (from_rotation)
+		{
+			local arr = is_boss ? Ware_BossgameRotation : Ware_MinigameRotation
+			RemoveElementIfFound(arr, minigame)
+		}
+		
 		local scope = Ware_LoadMinigame(minigame, player_count, is_boss, is_forced)
 		if (scope)
 		{		
 			// success!
 			Ware_MinigameScope = scope
-			
-			if (from_rotation)
-			{
-				local arr = is_boss ? Ware_BossgameRotation : Ware_MinigameRotation
-				local idx = arr.find(minigame)
-				if (idx != null)
-					arr.remove(idx)
-			}
-			
 			break
 		}
 	}


### PR DESCRIPTION
Fixes "no valid bossgame found" after mercenary kart removal, it would attempt to pick mercenary kart 16 times and error out