### PR TITLE
Noclip Basketball Disablement

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/minigames/basketball.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/basketball.nut
@@ -18,6 +18,15 @@ function OnPrecache()
 	PrecacheScriptSound(hoop_sound)
 }
 
+function OnPick()
+{
+	// noclip breaks this minigame
+	if(Ware_IsSpecialRoundSet("noclip")
+		return false
+
+	return true
+}
+
 function OnStart()
 {
 	Ware_SetGlobalLoadout(TF_CLASS_DEMOMAN, "Grenade Launcher", { "fuse bonus" : 0.6 })


### PR DESCRIPTION
The Basketball minigame can cause a fatal error during the Noclip special round if players try to enter the hoop.