### PR TITLE
Don't pick Mercenary Kart during Hunger Update special round

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/bossgames/mercenary_kart.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/mercenary_kart.nut
@@ -288,8 +288,8 @@ function OnPrecache()
 
 function OnPick()
 {
-	// cramped breaks this boss
-	if(Ware_IsSpecialRoundSet("cramped_quarters") || Ware_IsSpecialRoundSet("skull"))
+	// these special rounds break this boss
+	if(Ware_IsSpecialRoundSet("cramped_quarters") || Ware_IsSpecialRoundSet("skull")) || Ware_IsSpecialRoundSet("hunger_update"))
 		return false
 	
 	// this lags large servers too hard with high timescale


### PR DESCRIPTION
Players just die non-stop as snacks don't spawn on the track as they do on normal arenas