### PR TITLE
FOV special round rework

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/specialrounds/fov.nut
+++ b/scripts/vscripts/tf2ware_ultimate/specialrounds/fov.nut
@@ -1,23 +1,29 @@
-fov <- 130 
-
 special_round <- Ware_SpecialRoundData
 ({
-	name             = "Quake Pro"
-	author           = ["TonyBaretta", "ficool2"]
-	description      = "FOV increased to 130!"
-	category         = ""
+	name		= "Double Vision"
+	author		= ["TonyBaretta", "ficool2"]
+	description	= "Zoom in and zoom out."
+	category	= ""
 })
 
 function OnStart()
 {
+	local roll = RandomInt(1, 2)
+	local fov = 50
+	if (roll == 2) fov = 130
+
 	foreach (player in Ware_Players)
 		SetPropInt(player, "m_iFOV", fov)
 }
 
 function OnMinigameEnd()
 {
+	local roll = RandomInt(1, 2)
+	local fov = 50
+	if (roll == 2) fov = 130
+
 	foreach (player in Ware_Players)
-		SetPropInt(player, "m_iFOV", fov)	
+		SetPropInt(player, "m_iFOV", fov)
 }
 
 function OnEnd()


### PR DESCRIPTION
I've noticed in an old YT video that Quake Pro also had a second mode called Tunnel Vision. I assume it was removed, because it was very hard to play the whole round like this, so I've decided to combine both Quake Pro and Tunnel Vision into one special round.
I renamed it to Double Vision, as FOV changes between "two visions", and changed the description to "Zoom in and zoom out."
Now very low and very high FOV values randomly change between minigames, making it easier on the eyes and less repetitive.