### PR TITLE
Disable minicrits become crits

### DIFF
--- a/cfg/tf2ware_ultimate/melee_attributes.cfg
+++ b/cfg/tf2ware_ultimate/melee_attributes.cfg
@@ -184,7 +184,11 @@
 // vita saw
 [173] = { "max health additive penalty" : 0 },
 // bushwacka
-[232] = { "dmg taken increase" : 1 },
+[232] =
+{ 
+	"dmg taken increase" : 1 ,
+	"minicrits become crits" : 0 ,
+},
 // tribalman's shiv
 [171] = { "bleeding duration" : 0 },
 // conniver's kunai

--- a/scripts/vscripts/tf2ware_ultimate/default/melee_attributes.nut
+++ b/scripts/vscripts/tf2ware_ultimate/default/melee_attributes.nut
@@ -185,7 +185,11 @@ buffer<-@"// atomizer
 // vita saw
 [173] = { ""max health additive penalty"" : 0 },
 // bushwacka
-[232] = { ""dmg taken increase"" : 1 },
+[232] =
+{ 
+	""dmg taken increase"" : 1 ,
+	""minicrits become crits"" : 0 ,
+},
 // tribalman's shiv
 [171] = { ""bleeding duration"" : 0 },
 // conniver's kunai


### PR DESCRIPTION
This is used just to kill people with critical hits from the Cleaner's Carbine mini-crit buff in Buff minigame.