### PR TITLE
Rework Inclinity Problem special round and fix an error related to it

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/minigames/teleport.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/teleport.nut
@@ -41,20 +41,6 @@ minigame <- Ware_MinigameData
 	allow_damage   = true
 })
 
-function OnPick()
-{
-	return !Ware_IsSpecialRoundSet("inclinity_problem")
-	
-	// this is a bandaid solution
-	// the issue is the teleporters just steal the location's teleport players function, which assumes players but im using for teleporters
-	// but teleportplayer has a special round callback that relies on player data that teleporters dont have
-	// either i add a isplayer check there (kinda lame)
-	// or something else
-	// i was planning on making the locations table above, the values would be teleport functions instead
-	// but that is also a lot of work
-	// bleh
-}
-
 function OnTeleport(players)
 {
 	local center = Ware_MinigameLocation.center + Vector(0, 10000, 0)

--- a/scripts/vscripts/tf2ware_ultimate/specialrounds/inclinity_problem.nut
+++ b/scripts/vscripts/tf2ware_ultimate/specialrounds/inclinity_problem.nut
@@ -2,36 +2,36 @@ special_round <- Ware_SpecialRoundData
 ({
 	name = "Inclinity Problem"
 	author = "ficool2"
-	description = "The world tilts as much as your score!"
+	description = "The world tilts more after every minigame!"
 	category = ""
 })
 
-function SetGlobalPlayerRoll()
+roll <- 0
+direction <- 1
+
+function OnStart()
+{
+	roll = 0
+	direction = RandomInt(0, 1) ? 1 : -1
+}
+
+function OnUpdate()
 {
 	foreach (player in Ware_Players)
 	{
-		if (player.IsAlive())
+		if (!player.IsAlive())
+			continue
+
+		local eye_angles = player.EyeAngles()
+		if (fabs(eye_angles.z - (roll * direction)) > 0.1)
 		{
-			local eye_angles = player.EyeAngles()
-			local roll = GetPlayerRollAngle(player)
-			eye_angles.z = roll
-			player.ViewPunch(QAngle(0, 0, -roll))
+			eye_angles.z = roll * direction
 			player.SnapEyeAngles(eye_angles)
 		}
 	}
 }
 
-function OnStart()
-{
-	SetGlobalPlayerRoll()
-}
-
 function OnMinigameEnd()
 {
-	SetGlobalPlayerRoll()
-}
-
-function GetPlayerRollAngle(player)
-{
-	return player.GetScriptScope().ware_data.score
+	roll += 1.0
 }


### PR DESCRIPTION
It's not a team-based special round, but it affects players differently. Only Team Battles makes sense to be based on points, so here are some changes:
* All players' screens are now tilted at the same rate, rather than being based on points.
* Now it can randomly pick to either tilt players' screens to the left or right for the duration of the round.
* Fixed rare cases where the tilt effect was lost if players' first-person view was overwritten and then returned back to first-person during the same minigame/boss stage (for example, in Beep Block Skyway after teleporting between stages).
* Fixed [this error](https://github.com/ficool2/TF2Ware_Ultimate/issues/211).