### PR TITLE
Remove Extended Round from rotation

### DIFF
--- a/cfg/tf2ware_ultimate/specialrounds.cfg
+++ b/cfg/tf2ware_ultimate/specialrounds.cfg
@@ -8,7 +8,6 @@ cocanium
 collisions
 cramped_quarters
 double_trouble
-extended_round
 fov
 hale
 hunger_update

--- a/scripts/vscripts/tf2ware_ultimate/default/specialrounds.nut
+++ b/scripts/vscripts/tf2ware_ultimate/default/specialrounds.nut
@@ -10,7 +10,6 @@ cocanium
 collisions
 cramped_quarters
 double_trouble
-extended_round
 fov
 hale
 hunger_update


### PR DESCRIPTION
I’m not gonna sugarcoat it, it's a very boring special round that adds nothing new or interesting. Two Bosses, a very similar in concept special round, was already removed [382352c](https://github.com/ficool2/TF2Ware_Ultimate/commit/382352c258b0b1d74339885c047b83993b7db47f) and this could be too.