### PR TITLE
Remove Adrenaline Shot from rotation

### DIFF
--- a/cfg/tf2ware_ultimate/specialrounds.cfg
+++ b/cfg/tf2ware_ultimate/specialrounds.cfg
@@ -1,4 +1,3 @@
-adrenaline_shot
 all_in
 barrels
 bonk

--- a/scripts/vscripts/tf2ware_ultimate/default/specialrounds.nut
+++ b/scripts/vscripts/tf2ware_ultimate/default/specialrounds.nut
@@ -1,6 +1,5 @@
 // auto-generated file, do not edit. edit the matching file in the "cfg" folder instead
 buffer<-@"VERSION 9
-adrenaline_shot
 all_in
 barrels
 bonk


### PR DESCRIPTION
A combination of Time Attack and Slow-Mo. Both affect a round differently, while Adrenaline Shot adds nothing new by itself, and that's why it could be removed.