### PR TITLE
Quality of life changes and other additions to Cramped Quarters special round

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/bossgames/cuddly_heavies.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/cuddly_heavies.nut
@@ -44,6 +44,13 @@ function OnPrecache()
 	PrecacheParticle(love_particle)
 }
 
+function OnPick()
+{
+	// guarantee lost to the team with fewer players
+	if(Ware_IsSpecialRoundSet("cramped_quarters"))
+		return false
+}
+
 function OnStart()
 {
 	local vo_count = 0

--- a/scripts/vscripts/tf2ware_ultimate/bossgames/jump_rope.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/jump_rope.nut
@@ -20,6 +20,13 @@ jumprope_door <- null
 jumprope_mins <- null
 jumprope_maxs <- null
 
+function OnPick()
+{
+	// very little space for players
+	if(Ware_IsSpecialRoundSet("cramped_quarters"))
+		return false
+}
+
 function OnStart()
 {
 	Ware_SetGlobalAttribute("no double jump", 1, -1)

--- a/scripts/vscripts/tf2ware_ultimate/bossgames/slender.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/slender.nut
@@ -127,6 +127,13 @@ function OnPrecache()
 	PrecacheModel(page_model)
 }
 
+function OnPick()
+{
+	// guarantee lost to the team with fewer players
+	if(Ware_IsSpecialRoundSet("cramped_quarters"))
+		return false
+}
+
 function OnStart()
 {
 	fog = Ware_SpawnEntity("env_fog_controller",

--- a/scripts/vscripts/tf2ware_ultimate/minigames/stun.nut
+++ b/scripts/vscripts/tf2ware_ultimate/minigames/stun.nut
@@ -44,12 +44,12 @@ function OnUpdate()
 
 function OnTakeDamage(params)
 {
-	params.damage = 0.0
-	
 	if (params.damage_stats == TF_DMG_CUSTOM_BASEBALL)
 	{
 		local victim = params.const_entity
 		local attacker = params.attacker
+	
+		params.damage = 0.0
 	
 		victim.StunPlayer(Ware_GetMinigameRemainingTime(), 0.6, TF_STUN_SPECIAL_SOUND|TF_STUN_MOVEMENT, null)
 		
@@ -63,6 +63,10 @@ function OnTakeDamage(params)
 		
 		if (attacker)
 			Ware_PassPlayer(attacker, true)
+	}
+	else if (!touch_dmg)
+	{
+		params.damage = 0.0
 	}
 }
 

--- a/scripts/vscripts/tf2ware_ultimate/specialrounds/cramped_quarters.nut
+++ b/scripts/vscripts/tf2ware_ultimate/specialrounds/cramped_quarters.nut
@@ -9,11 +9,27 @@ special_round <- Ware_SpecialRoundData
 
 local touch_dmg = false
 local grace = false
+local grace_warning = false
+local disabled_msg_this_round = false
+local last_minigame = null
+
+function IsDisabledMinigame()
+{
+	if (!Ware_Minigame)
+		return false
+
+	return (
+		Ware_Minigame.name == "Basketball" || Ware_Minigame.name == "Floppy Scout" || Ware_Minigame.name == "Shark" || Ware_Minigame.name == "Trampoline" || Ware_Minigame.name == "Trivia"
+	)
+}
 
 function OnStart()
 {
 	foreach(player in Ware_Players)
 		Ware_GetPlayerSpecialRoundData(player).touched <- false
+
+	disabled_msg_this_round = false
+	last_minigame = Ware_Minigame
 }
 
 function OnPlayerSpawn(player)
@@ -23,9 +39,31 @@ function OnPlayerSpawn(player)
 
 function OnPlayerTouch(player1, player2)
 {
-	if(grace)
+	if (grace)
+	{
+		if(!grace_warning)
+		{
+			Ware_ChatPrint(null,
+				"{color}The grace period is still active. {color}Stay away{color}!",
+				TF_COLOR_DEFAULT, TF_COLOR_RED, TF_COLOR_DEFAULT)
+
+			grace_warning = true
+		}
+
 		return
-	
+	}
+
+	if (IsDisabledMinigame())
+	{
+		if (!disabled_msg_this_round)
+		{
+			Ware_ChatPrint(null,
+				"Cramped Quarters is disabled during this minigame.")
+			disabled_msg_this_round = true
+		}
+		return
+	}
+
 	if (Ware_Minigame || Ware_Finished)
 	{
 		touch_dmg = true	
@@ -34,7 +72,7 @@ function OnPlayerTouch(player1, player2)
 		player1.TakeDamage(1000.0, DMG_BULLET, player2)
 		SetPropBool(GameRules, "m_bTruceActive", truce)
 		touch_dmg = false
-		
+
 		// don't spam the chat if killing somehow fails, but still try to kill.
 		local data = Ware_GetPlayerSpecialRoundData(player1)
 		if(!data.touched)
@@ -54,6 +92,19 @@ function OnTakeDamage(params)
 
 function OnMinigameStart()
 {
+	if (last_minigame != Ware_Minigame)
+	{
+		disabled_msg_this_round = false
+		last_minigame = Ware_Minigame
+	}
+
+	if (IsDisabledMinigame())
+		return
+
 	grace = true
-	Ware_CreateTimer(function(){grace = false}, Min(1.0, Ware_Minigame.duration / 4))
+	grace_warning = false
+
+	local grace_time = (Ware_Minigame.duration >= 40.0) ? 10.0 : 2.5
+
+	Ware_CreateTimer(function(){grace = false}, grace_time)
 }


### PR DESCRIPTION
Here are all changes:

- The special round is now disabled in a few minigames and boss stages due to either being able to "kamikaze" the enemy team to win/allow your team to easily win or when there's very little space for players to move:
**Basketball** - very little space to move around
**Floppy Scout** - very little space to move and all players move in the same direction
**Shark** - Soldiers can kill the shark to give their team an easy win
**Trampoline** - very little space to move around
**Trivia** - players are invisible
**Cuddly Heavies** - Scouts can kill Heavies to give their team an easy win
**Jump Rope** - very little space to move around
**Slender** - Medics can kill Spies to give their team an easy win
- Now the grace period lasts 2.5 sec for minigames and 10 seconds for boss stages. Before, the grace period was so short I thought there was none before I checked the code. It's longer for boss stages, as they are way more important than minigames. For boss stages, it checks for their duration. The longest minigame lasts 37 seconds, and the shortest boss stage lasts 40 seconds, so it should work for everything new added in the future as long as a minigame doesn't last more than 39 seconds.
- Now players will see in chat if they touched another player during the grace period and will be informed to stay away.
- It will also inform players if kill on touch is disabled in specific minigames mentioned above.
- Fixed kill on touch not working in Stun an Enemy minigame.