### PR TITLE
Double up mandrill blocks (Closes #50)

### DIFF
--- a/scripts/vscripts/tf2ware_ultimate/bossgames/mandrill.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/mandrill.nut
@@ -58,6 +58,14 @@ function OnStart()
 					disableshadows = true
 					disablereceiveshadows = true
 				})
+				
+				Ware_SpawnEntity("func_brush",
+					{
+						origin = block_pos + Vector(0, 0, 208) // these blocks arent square..... :(
+						model          = block_model
+						disableshadows = true
+						disablereceiveshadows = true
+					})
 			}
 		}
 		//print("\n")

--- a/scripts/vscripts/tf2ware_ultimate/bossgames/mandrill.nut
+++ b/scripts/vscripts/tf2ware_ultimate/bossgames/mandrill.nut
@@ -60,12 +60,12 @@ function OnStart()
 				})
 				
 				Ware_SpawnEntity("func_brush",
-					{
-						origin = block_pos + Vector(0, 0, 208) // these blocks arent square..... :(
-						model          = block_model
-						disableshadows = true
-						disablereceiveshadows = true
-					})
+				{
+					origin = block_pos + Vector(0, 0, 208) // these blocks arent square..... :(
+					model          = block_model
+					disableshadows = true
+					disablereceiveshadows = true
+				})
 			}
 		}
 		//print("\n")


### PR DESCRIPTION
This doubles up the mandrill blocks by, for each cell in the maze, spawning an additional block above the first one if a block is being spawned there.

I want ficool to sign off on this since

1. it adds around +100 edicts
2. it is a bit more obvious where the edge of the maze is (but i think thats fine)